### PR TITLE
Add missing HTTPError and TimeoutError exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,13 @@ if (!global.fetch) {
 	global.AbortController = AbortController;
 }
 
-const {default: ky} = require('ky/umd');
+const {
+	default: ky,
+	HTTPError,
+	TimeoutError
+} = require('ky/umd');
 
 module.exports = ky;
 module.exports.default = ky;
+module.exports.HTTPError = HTTPError;
+module.exports.TimeoutError = TimeoutError;


### PR DESCRIPTION
HTTPError and TimeoutError classes are imported from `ky/umd` and re-exported to allow following usage: 

```javascript
const { HTTPError, TimeoutError } = require('ky-universal')
```

Fixes #4