### PR TITLE
Use CommonJS export in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export {default} from 'ky';
+import ky from 'ky';
+
+export = ky;


### PR DESCRIPTION
Relates to #16 

This PR attempts to fix the issue described in https://github.com/sindresorhus/ky-universal/issues/16#issuecomment-616512923 so that TypeScript users are able to do `import ky = require('ky-universal');`.