### PR TITLE
Use node-fetch v3 beta and require Node.js 10.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '13'
+  - '14'
   - '12'
   - '10'

--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
 if (!global.fetch) {
-	global.fetch = (url, options) => {
-		return fetch(url, {...options, ...{highWaterMark: 10240 * 1024}});
-	};
+	global.fetch = (url, options) => fetch(url, {...options, ...{highWaterMark: 10240 * 1024}});
 }
 
 if (!global.Headers) {

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@
 const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
+const TEN_MEGABYTES = 1000 * 1000 * 10;
+
 if (!global.fetch) {
-	global.fetch = (url, options) => fetch(url, {...options, ...{highWaterMark: 10240 * 1024}});
+	global.fetch = (url, options) => fetch(url, {...options, ...{highWaterMark: TEN_MEGABYTES}});
 }
 
 if (!global.Headers) {

--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@
 const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
+const DEFAULT = 16384;
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 if (!global.fetch) {
-	global.fetch = options => fetch(options.url, Object.assign(options, {highWaterMark: options.highWaterMark || TEN_MEGABYTES}));
+	global.fetch = options => fetch(options.url, {...options, highWaterMark: options.highWaterMark === DEFAULT ? TEN_MEGABYTES : options.highWaterMark});
 }
 
 if (!global.Headers) {

--- a/index.js
+++ b/index.js
@@ -2,11 +2,10 @@
 const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
-const DEFAULT = 16384;
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 if (!global.fetch) {
-	global.fetch = options => fetch(options.url, {...options, highWaterMark: options.highWaterMark === DEFAULT ? TEN_MEGABYTES : options.highWaterMark});
+	global.fetch = (url, options) => fetch(url, {highWaterMark: TEN_MEGABYTES, ...options});
 }
 
 if (!global.Headers) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
-const TEN_MEGABYTES = 10240 * 1024;
+const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 if (!global.fetch) {
 	global.fetch = options => fetch(options.url, Object.assign(options, {highWaterMark: options.highWaterMark || TEN_MEGABYTES}));

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
 if (!global.fetch) {
-	global.fetch = fetch;
+	global.fetch = (url, options) => fetch(url, {options, ...{highWaterMark: 10240 * 1024}});
 }
 
 if (!global.Headers) {

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
-const TEN_MEGABYTES = 1000 * 1000 * 10;
+const TEN_MEGABYTES = 10240 * 1024;
 
 if (!global.fetch) {
-	global.fetch = (url, options) => fetch(url, {...options, ...{highWaterMark: TEN_MEGABYTES}});
+	global.fetch = options => fetch(options.url, Object.assign(options, {highWaterMark: options.highWaterMark || TEN_MEGABYTES}));
 }
 
 if (!global.Headers) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ const fetch = require('node-fetch');
 const AbortController = require('abort-controller');
 
 if (!global.fetch) {
-	global.fetch = (url, options) => fetch(url, {options, ...{highWaterMark: 10240 * 1024}});
+	global.fetch = (url, options) => {
+		return fetch(url, {...options, ...{highWaterMark: 10240 * 1024}});
+	};
 }
 
 if (!global.Headers) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	],
 	"dependencies": {
 		"abort-controller": "^3.0.0",
-		"node-fetch": "^2.6.0"
+		"node-fetch": "^3.0.0-beta.5"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=10.16"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -54,7 +54,7 @@
 	],
 	"dependencies": {
 		"abort-controller": "^3.0.0",
-		"node-fetch": "^3.0.0-beta.5"
+		"node-fetch": "^3.0.0-beta.6-exportfix"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ The library that uses Ky will now *just work* in AVA tests.
 
 #### `clone()` hangs with a large response in Node - What should I do?
 
-Stream in Node.js have a smaller internal buffer size (16Kb, aka `highWaterMark`) from client-side browsers (>1MB, not consistent across browsers). Because of that, when you are writing an isomorphic app and using `res.clone()`, it will hang with large response in Node.
+Stream in Node.js have a smaller internal buffer size (16kB, aka `highWaterMark`) from client-side browsers (>1MB, not consistent across browsers). Because of that, when you are writing an isomorphic app and using `res.clone()`, it will hang with large response in Node.
 
 One way to fix this is to specify the `highWaterMark`:
 

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ The library that uses Ky will now *just work* in AVA tests.
 
 #### `clone()` hangs with a large response in Node - What should I do?
 
-Stream in Node.js have a smaller internal buffer size (16Kb, aka `highWaterMark`) from client-side browsers (>1Mb, not consistent across browsers). Because of that, when you are writing an isomorphic app and using `res.clone()`, it will hang with large response in Node.
+Stream in Node.js have a smaller internal buffer size (16Kb, aka `highWaterMark`) from client-side browsers (>1MB, not consistent across browsers). Because of that, when you are writing an isomorphic app and using `res.clone()`, it will hang with large response in Node.
 
 One way to fix this is to specify the `highWaterMark`:
 
@@ -106,7 +106,7 @@ import ky from 'ky-universal';
 
 (async () => {
 	const response = await ky('https://example.com', {
-		// About 1Mb
+		// About 1MB
 		highWaterMark: 1024 * 1024
 	});
 

--- a/readme.md
+++ b/readme.md
@@ -97,9 +97,9 @@ The library that uses Ky will now *just work* in AVA tests.
 
 #### `clone()` hangs with a large response in Node - What should I do?
 
-Streams in Node.js have a smaller internal buffer size (16 kB, aka `highWaterMark`) from client-side browsers (>1 MB, not consistent across browsers). When using Ky, the default `highWaterMark` is set to 10 MB, so you shouldn't encounter many issues related to that.
+Streams in Node.js have a smaller internal buffer size (16 kB, aka `highWaterMark`) than browsers (>1 MB, not consistent across browsers). When using Ky, the default `highWaterMark` is set to 10 MB, so you shouldn't encounter many issues related to that.
 
-However, you can specify a custom `highWaterMark` if you need:
+However, you can specify a custom `highWaterMark` if needed:
 
 ```js
 import ky from 'ky-universal';

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ const ky = require('ky-universal');
 	const {body} = await ky('https://httpbin.org/bytes/16');
 	const {value} = await body.getReader().read();
 	const result = new TextDecoder('utf-8').decode(value);
-	
+
 	// …
 })();
 ```
@@ -94,6 +94,25 @@ Put the following in package.json:
 ```
 
 The library that uses Ky will now *just work* in AVA tests.
+
+#### `clone()` hangs with a large response in Node - What should I do?
+
+Stream in Node.js have a smaller internal buffer size (16Kb, aka `highWaterMark`) from client-side browsers (>1Mb, not consistent across browsers). Because of that, when you are writing an isomorphic app and using `res.clone()`, it will hang with large response in Node.
+
+One way to fix this is to specify the `highWaterMark`:
+
+```js
+import ky from 'ky-universal';
+
+(async () => {
+	const response = await ky('https://example.com', {
+		// About 1Mb
+		highWaterMark: 1024 * 1024
+	});
+
+	const data = await response.clone().buffer();
+})();
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ import ky from 'ky-universal';
 (async () => {
 	const response = await ky('https://example.com', {
 		// 20 MB
-		highWaterMark: 1000 * 1000
+		highWaterMark: 1000 * 1000 * 20
 	});
 
 	const data = await response.clone().buffer();

--- a/readme.md
+++ b/readme.md
@@ -97,17 +97,17 @@ The library that uses Ky will now *just work* in AVA tests.
 
 #### `clone()` hangs with a large response in Node - What should I do?
 
-Stream in Node.js have a smaller internal buffer size (16kB, aka `highWaterMark`) from client-side browsers (>1MB, not consistent across browsers). Because of that, when you are writing an isomorphic app and using `res.clone()`, it will hang with large response in Node.
+Streams in Node.js have a smaller internal buffer size (16kB, aka `highWaterMark`) from client-side browsers (>1MB, not consistent across browsers). When using Ky, the default `highWaterMark` is set to 10MB, so you shouldn't encounter many issues related to that.
 
-One way to fix this is to specify the `highWaterMark`:
+However, you are able to specify custom `highWaterMark`:
 
 ```js
 import ky from 'ky-universal';
 
 (async () => {
 	const response = await ky('https://example.com', {
-		// About 1MB
-		highWaterMark: 1024 * 1024
+		// 20MB
+		highWaterMark: 20971520
 	});
 
 	const data = await response.clone().buffer();

--- a/readme.md
+++ b/readme.md
@@ -97,17 +97,17 @@ The library that uses Ky will now *just work* in AVA tests.
 
 #### `clone()` hangs with a large response in Node - What should I do?
 
-Streams in Node.js have a smaller internal buffer size (16kB, aka `highWaterMark`) from client-side browsers (>1MB, not consistent across browsers). When using Ky, the default `highWaterMark` is set to 10MB, so you shouldn't encounter many issues related to that.
+Streams in Node.js have a smaller internal buffer size (16 kB, aka `highWaterMark`) from client-side browsers (>1 MB, not consistent across browsers). When using Ky, the default `highWaterMark` is set to 10 MB, so you shouldn't encounter many issues related to that.
 
-However, you are able to specify custom `highWaterMark`:
+However, you can specify a custom `highWaterMark` if you need:
 
 ```js
 import ky from 'ky-universal';
 
 (async () => {
 	const response = await ky('https://example.com', {
-		// 20MB
-		highWaterMark: 20971520
+		// 20 MB
+		highWaterMark: 1000 * 1000
 	});
 
 	const data = await response.clone().buffer();


### PR DESCRIPTION
Fixes #8 (allows using the `highWaterMark` option)

---

We have a [section](https://github.com/node-fetch/node-fetch#custom-highwatermark) in the node-fetch's readme about custom `highWaterMark`. Let me know if we should link it somewhere here :smile:


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#8: clone() hangs with large response in Node](https://issuehunt.io/repos/172099953/issues/8)
---
</details>
<!-- /Issuehunt content-->