### PR TITLE
Fix semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	],
 	"dependencies": {
 		"abort-controller": "^3.0.0",
-		"node-fetch": "^3.0.0-beta.7"
+		"node-fetch": "3.0.0-beta.7"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
The freshly released version 0.8 still uses `node-fetch@3.0.0-beta.6-exportfix`.

Solution is to lock the node-fetch version. 

```
warning node-fetch@3.0.0-beta.6-exportfix: This release contains some TypeScript definition issues and we therefore recommend to update to the next version. Changelog: https://git.io/JfV1D
``` 

> This also breaks install with yarn (at least with my setup: workspace/lerna/node12 -.
> `error fetch-blob@1.0.7: The engine "node" is incompatible with this module. Expected version "^10.17.0". Got "12.14.1"`