### PR TITLE
Update node-fetch to 3.0.0-beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	],
 	"dependencies": {
 		"abort-controller": "^3.0.0",
-		"node-fetch": "^3.0.0-beta.9"
+		"node-fetch": "3.0.0-beta.9"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	],
 	"dependencies": {
 		"abort-controller": "^3.0.0",
-		"node-fetch": "3.0.0-beta.7"
+		"node-fetch": "^3.0.0-beta.9"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
There was a security update for node-fetch.

> This is an important security release. It is strongly recommended to update as soon as possible.
https://github.com/node-fetch/node-fetch/blob/master/docs/CHANGELOG.md#v300-beta9